### PR TITLE
Update program to be compatible with current version of Google URL Shortener API and urllib.request module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.py
+__pycache__
+venv

--- a/config.orig.py
+++ b/config.orig.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+API_KEY = ""

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,67 @@
+# google_shortener
+
+Originally this code is totally created by http://stackoverflow.com/a/1
+7357552/1401639 ( https://goo.gl/PJbo90 ).
+
+This program is tested with Python 3.
+
+We need Google URL Shortener API Key in order to run this program.
+
+We use only API Key without OAuth 2.0 authentication as we don't need
+to access individual's private data.
+
+Steps to acquire Google URL Shortener API Key are as follows:
+  - Go to https://console.developers.google.com/apis/api/urlshortener/
+    overview ( https://goo.gl/E7oUw7 ).
+  - Click 'Create project'.
+  - Click 'Create a project'.  Set 'Project name' to be anything you
+    want.  For me, I set it to be 'google-shortener'.
+  - Click 'Enable'.  Click 'Go to Credentails'.
+  - Which API are you using?
+    Answer: URL Shortener API
+  - Where will you be calling the API from?
+    Answer: Other non-UI (e.g. cron job, daemon)
+  - What data will you be accessing?
+    Answer: Public data
+  - Click 'What credentials do I need?'.
+  - Copy your API Key!
+  - Click 'Done'.
+
+You can set the API Key you get above in the file /config.py at the
+variable API_KEY.
+
+References
+  - https://developers.google.com/url-shortener/
+
+# How To Run This Program
+
+- Acquire Google URL Shortener API Key per instructions above
+  (Steps to acquire Google URL Shortener API Key).
+
+- Assuming your current directory is the project root directory.
+
+- Make sure you use Python 3 to run it.  I use virtualenv as below.
+
+  Create virtualenv (for Python 3) and activate it.
+
+  ~~~
+  $ virtualenv venv
+  $ source ./venv/bin/activate
+  ~~~
+
+- Run it (You might want to `chmod +x shortener.py` first.)
+
+  ~~~
+  $ ./shortener.py SOME_URL
+  ~~~
+
+  Example
+
+  ~~~
+  $ ./shortener.py "https://developers.google.com/url-shortener/"
+
+  # OUTPUT
+
+  https://goo.gl/pZbaF
+  ~~~
+

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,10 @@ References
 
 - Assuming your current directory is the project root directory.
 
+- `$ mv config.orig.py config.py`
+
+- Set your API Key to variable API_KEY inside the file 'config.py'.
+
 - Make sure you use Python 3 to run it.  I use virtualenv as below.
 
   Create virtualenv (for Python 3) and activate it.

--- a/shortener.py
+++ b/shortener.py
@@ -1,23 +1,34 @@
-"""
-Totally created by http://stackoverflow.com/a/17357552/1401639
-"""
+#!/usr/bin/env python
 
-import urllib2
+import urllib.request
+import urllib.parse
 import json
+import sys
 
+import config
+
+# List of constants.
 API_URL = 'https://www.googleapis.com/urlshortener/v1/url'
 
+# Shorten URL using Google's url-shortener API.
 def shorten(url):
-    postdata = {'longUrl':url}
-    headers = {'Content-Type':'application/json'}
-    req = urllib2.Request(
-        API_URL,
-        json.dumps(postdata),
-        headers
-    )
-    ret = urllib2.urlopen(req).read()
-    return json.loads(ret)['id']
+  # Prepare data to be POSTed to Google.
+  json_post_data = json.dumps({'longUrl': url})
 
+  # POST request to Google.
+  req = urllib.request.Request(
+    url = API_URL + "?key=" + config.API_KEY,
+    data = json_post_data.encode('utf-8'),
+    headers ={
+      'Content-Type': 'application/json',
+      'Content-Length': len(json_post_data)})
+  
+  # Read result from Google.
+  with urllib.request.urlopen(req) as f:
+    ret = f.read().decode('utf-8')
+
+  # Shorten URL is inside property 'id'.
+  return json.loads(ret)['id']
 
 """
 Return **True** if *url* looks like a result of
@@ -26,12 +37,19 @@ the *shorten* function. Return **False** other way.
 def is_short(url):
     return url.startswith('http://goo.gl/')
 
-
+# FIXME: Might need to be updated later using similar approach as in
+# function shorten.  Right now, I don't have time and all I need is
+# shortening which has been fixed.
+# 
+# by dragontortoise
 def expand(url):
     """
     :url: short url to expand.
     :returns: string, full url.
     """
     return json.loads(urllib2.urlopen(\
-        '{0}?shortUrl={1}'.format(API_URL, url)).\
-        read())['longUrl']
+        '{0}?key={1}&shortUrl={2}'.format(API_URL, config.API_KEY,
+        url)).read())['longUrl']
+
+if __name__ == "__main__":
+    print(shorten(sys.argv[1]))


### PR DESCRIPTION
The last version might be outdated. When I ran it, I got HTTP 403 Error
as a response.

This commit fixes it by using Python 3 and the new urllib.request
module.  I also have to use API Key as calling Google's URL Shortener
service without authentication is troublesome.  For example, it asks
me to verify if I am a human or it tells me the IP address I am using
has already exhausted its quota (???) (We need IPv6 now, don't we?!).

I also make shortener.py to be executable too so you can just use it
from your favourite shell.